### PR TITLE
Improve hero images and logo LCP

### DIFF
--- a/src/app/head.tsx
+++ b/src/app/head.tsx
@@ -1,4 +1,9 @@
 // src/app/head.tsx
+import humarsupa from '../../public/humarsupa_portrait.jpg';
+import fiskibollur from '../../public/fiskibollur_portrait.jpg';
+import fiskistangir from '../../public/fiskistangir_portrait.jpg';
+import plokkfiskur from '../../public/plokkfiskur_portrait.jpg';
+
 export default function Head() {
   return (
     <>
@@ -82,10 +87,10 @@ export default function Head() {
       />
 
       {/* 3) Preload all four desktop-hero images when viewport is ≥ 769px */}
-      <link rel="preload" as="image" href="/humarsupa_portrait.jpg" media="(min-width: 769px)" />
-      <link rel="preload" as="image" href="/fiskibollur_portrait.jpg" media="(min-width: 769px)" />
-      <link rel="preload" as="image" href="/fiskistangir_portrait.jpg" media="(min-width: 769px)" />
-      <link rel="preload" as="image" href="/plokkfiskur_portrait.jpg" media="(min-width: 769px)" />
+      <link rel="preload" as="image" href={humarsupa.src} media="(min-width: 769px)" />
+      <link rel="preload" as="image" href={fiskibollur.src} media="(min-width: 769px)" />
+      <link rel="preload" as="image" href={fiskistangir.src} media="(min-width: 769px)" />
+      <link rel="preload" as="image" href={plokkfiskur.src} media="(min-width: 769px)" />
     </>
   );
 }

--- a/src/components/functions/Header.tsx
+++ b/src/components/functions/Header.tsx
@@ -52,6 +52,8 @@ export default function Header() {
               alt="Grímur Kokkur logo"
               width={100}
               height={100}
+              priority
+              fetchPriority="high"
             />
           </Link>
         </div>

--- a/src/components/homePage/DesktopHero.tsx
+++ b/src/components/homePage/DesktopHero.tsx
@@ -1,8 +1,8 @@
 // src/components/homePage/DesktopHero.tsx
-import Image from 'next/image';
+import Image, { type StaticImageData } from 'next/image';
 import styles from '@/styles/HeroSection.module.scss';
 
-type Panel = { url: string; alt?: string };
+type Panel = { src: StaticImageData; alt?: string };
 
 interface DesktopHeroProps {
   panels: Panel[];
@@ -13,12 +13,12 @@ export default function DesktopHero({ panels }: DesktopHeroProps) {
     <header className={styles.hero} role="banner" aria-labelledby="hero-title">
       {panels.map((p, i) => {
         // The first panel is Humarsúpa; mark it as priority so it isn't lazy-loaded
-        const isHumarsupa = p.url.endsWith('humarsupa_portrait.jpg');
+        const isHumarsupa = /humarsupa_portrait/.test(p.src.src);
 
         return (
           <div key={i} className={`${styles.panel} ${styles[`panel${i + 1}`]}`}>
             <Image
-              src={p.url}
+              src={p.src}
               alt={p.alt || ''}
               priority={isHumarsupa}
               fill

--- a/src/components/homePage/HeroCarousel.tsx
+++ b/src/components/homePage/HeroCarousel.tsx
@@ -2,11 +2,11 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import Image from 'next/image';
+import Image, { type StaticImageData } from 'next/image';
 import styles from '@/styles/HeroCarousel.module.scss';
 
 interface HeroCarouselProps {
-  images: { url: string; alt?: string }[];
+  images: { src: StaticImageData; alt?: string }[];
   intervalMs?: number;
 }
 
@@ -32,7 +32,7 @@ export default function HeroCarousel({ images, intervalMs = 3000 }: HeroCarousel
         {images.map((img, i) => (
           <div key={i} className={styles.slide}>
             <Image
-              src={img.url}
+              src={img.src}
               alt={img.alt || `Slide ${i + 1}`}
               fill
               priority={true}

--- a/src/components/homePage/HeroSection.tsx
+++ b/src/components/homePage/HeroSection.tsx
@@ -5,12 +5,16 @@ import { useState, useEffect } from 'react';
 import useIsMobile from './useIsMobile';
 import DesktopHero from './DesktopHero';
 import MobileHeroCarousel from './MobileHeroCarousel';
+import humarsupa from '../../../public/humarsupa_portrait.jpg';
+import fiskibollur from '../../../public/fiskibollur_portrait.jpg';
+import fiskistangir from '../../../public/fiskistangir_portrait.jpg';
+import plokkfiskur from '../../../public/plokkfiskur_portrait.jpg';
 
 const panels = [
-  { url: '/humarsupa_portrait.jpg', alt: 'Humarsúpa' },
-  { url: '/fiskibollur_portrait.jpg', alt: 'Fiskibollur' },
-  { url: '/fiskistangir_portrait.jpg', alt: 'Fiskistangir' },
-  { url: '/plokkfiskur_portrait.jpg', alt: 'Plokkfiskur' },
+  { src: humarsupa, alt: 'Humarsúpa' },
+  { src: fiskibollur, alt: 'Fiskibollur' },
+  { src: fiskistangir, alt: 'Fiskistangir' },
+  { src: plokkfiskur, alt: 'Plokkfiskur' },
 ];
 
 export default function HeroSection() {

--- a/src/components/homePage/MobileHeroCarousel.tsx
+++ b/src/components/homePage/MobileHeroCarousel.tsx
@@ -2,11 +2,11 @@
 'use client';
 
 import { useEffect } from 'react';
-import Image from 'next/image';
+import Image, { type StaticImageData } from 'next/image';
 import useEmblaCarousel from 'embla-carousel-react';
 import styles from '@/styles/HeroCarousel.module.scss';
 
-type Panel = { url: string; alt?: string };
+type Panel = { src: StaticImageData; alt?: string };
 
 interface MobileHeroCarouselProps {
   panels: Panel[];
@@ -33,7 +33,7 @@ export default function MobileHeroCarousel({ panels }: MobileHeroCarouselProps) 
           <div key={i} className={styles.slide}>
             <div style={{ position: 'relative', width: '100%', height: '100%' }}>
               <Image
-                src={p.url}
+                src={p.src}
                 alt={p.alt || `Slide ${i + 1}`}
                 fill
                 sizes="100vw"


### PR DESCRIPTION
## Summary
- avoid lazy loading the logo
- import hero images as static assets
- preload hero images with hashed paths

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6842a21f44548324bcc51668eaf0ca34