### PR TITLE
Improve hero carousel UX

### DIFF
--- a/src/components/homePage/MobileHeroCarousel.tsx
+++ b/src/components/homePage/MobileHeroCarousel.tsx
@@ -1,9 +1,10 @@
 // src/components/homePage/MobileHeroCarousel.tsx
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import Image, { type StaticImageData } from 'next/image';
 import useEmblaCarousel from 'embla-carousel-react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import styles from '@/styles/HeroCarousel.module.scss';
 
 type Panel = { src: StaticImageData; alt?: string };
@@ -15,15 +16,22 @@ interface MobileHeroCarouselProps {
 export default function MobileHeroCarousel({ panels }: MobileHeroCarouselProps) {
   // 1) get Embla reference & API to control the carousel
   const [emblaRef, emblaApi] = useEmblaCarousel({ loop: true });
+  const [selectedIndex, setSelectedIndex] = useState(0);
 
   // 2) Auto‐advance every 3s
   useEffect(() => {
     if (!emblaApi) return;
+    setSelectedIndex(emblaApi.selectedScrollSnap());
+    const onSelect = () => setSelectedIndex(emblaApi.selectedScrollSnap());
+    emblaApi.on('select', onSelect);
     const interval = setInterval(() => {
       emblaApi.scrollNext();
     }, 3000);
 
-    return () => clearInterval(interval);
+    return () => {
+      clearInterval(interval);
+      emblaApi.off('select', onSelect);
+    };
   }, [emblaApi]);
 
   return (
@@ -42,6 +50,33 @@ export default function MobileHeroCarousel({ panels }: MobileHeroCarouselProps) 
               />
             </div>
           </div>
+        ))}
+      </div>
+
+      <button
+        className={`${styles.navButton} ${styles.prev}`}
+        onClick={() => emblaApi?.scrollPrev()}
+        aria-label="Fyrri mynd"
+      >
+        <ChevronLeft size={24} />
+      </button>
+      <button
+        className={`${styles.navButton} ${styles.next}`}
+        onClick={() => emblaApi?.scrollNext()}
+        aria-label="Næsta mynd"
+      >
+        <ChevronRight size={24} />
+      </button>
+      <div className={styles.dots} role="tablist">
+        {panels.map((_, index) => (
+          <button
+            key={index}
+            onClick={() => emblaApi?.scrollTo(index)}
+            className={`${styles.dot} ${index === selectedIndex ? styles.activeDot : ''}`}
+            aria-label={`Fara á mynd ${index + 1}`}
+            role="tab"
+            aria-selected={index === selectedIndex}
+          />
         ))}
       </div>
 

--- a/src/styles/HeroCarousel.module.scss
+++ b/src/styles/HeroCarousel.module.scss
@@ -3,7 +3,7 @@
   position: relative;
   overflow: hidden;
   width: 100%;
-  aspect-ratio: 20 / 30;
+  aspect-ratio: 3 / 4; // slightly taller on mobile for better visibility
 }
 
 .slides {
@@ -16,6 +16,55 @@
   position: relative;
   min-width: 100%;
   height: 100%;
+}
+
+.navButton {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(0, 0, 0, 0.4);
+  color: white;
+  border: none;
+  padding: 0.4rem;
+  border-radius: 9999px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  &:hover {
+    background: rgba(0, 0, 0, 0.6);
+  }
+}
+
+.prev {
+  left: 0.5rem;
+}
+
+.next {
+  right: 0.5rem;
+}
+
+.dots {
+  position: absolute;
+  bottom: 0.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 0.4rem;
+  z-index: 10;
+}
+
+.dot {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.5);
+  border: none;
+}
+
+.activeDot {
+  background: white;
 }
 
 .overlayContent {


### PR DESCRIPTION
## Summary
- add navigation buttons and page indicators to mobile carousel
- tweak image aspect ratio for mobile hero slideshow

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a745fc948324b88775ea17ccca1d