### PR TITLE
Fix hero carousel wrap-around

### DIFF
--- a/src/components/homePage/HeroCarousel.tsx
+++ b/src/components/homePage/HeroCarousel.tsx
@@ -11,7 +11,11 @@ interface HeroCarouselProps {
 }
 
 export default function HeroCarousel({ images, intervalMs = 3000 }: HeroCarouselProps) {
-  const [index, setIndex] = useState(0);
+  // Duplicate first and last images so we can seamlessly loop in one direction
+  const slides = [images[images.length - 1], ...images, images[0]];
+
+  // Start on the first real slide (index 1 within the duplicated list)
+  const [index, setIndex] = useState(1);
   const [enableTransition, setEnableTransition] = useState(true);
 
   // Auto‐advance
@@ -20,18 +24,21 @@ export default function HeroCarousel({ images, intervalMs = 3000 }: HeroCarousel
       setIndex((i) => i + 1);
     }, intervalMs);
     return () => clearInterval(tid);
-  }, [images.length, intervalMs]);
+  }, [intervalMs]);
 
   useEffect(() => {
-    if (index === images.length) {
+    // When we slide onto the duplicate at the end, jump back to the
+    // first real slide without animation once the transition is done.
+    if (index === slides.length - 1) {
       const timeout = setTimeout(() => {
         setEnableTransition(false);
-        setIndex(0);
+        setIndex(1);
       }, 1000); // match CSS transition duration
       return () => clearTimeout(timeout);
     }
+
     setEnableTransition(true);
-  }, [index, images.length]);
+  }, [index, slides.length]);
 
   return (
     <div className={styles.carouselWrapper}>
@@ -44,29 +51,18 @@ export default function HeroCarousel({ images, intervalMs = 3000 }: HeroCarousel
         aria-live="polite"
         aria-atomic="true"
       >
-        {images.map((img, i) => (
+        {slides.map((img, i) => (
           <div key={i} className={styles.slide}>
             <Image
               src={img.src}
-              alt={img.alt || `Slide ${i + 1}`}
+              alt={img.alt || ''}
               fill
-              priority={true}
+              priority={i === 1}
               sizes="100vw"
               style={{ objectFit: 'cover' }}
             />
           </div>
         ))}
-        {/* duplicate first slide for seamless looping */}
-        <div className={styles.slide} aria-hidden="true">
-          <Image
-            src={images[0].src}
-            alt={images[0].alt || 'Slide 1'}
-            fill
-            priority={false}
-            sizes="100vw"
-            style={{ objectFit: 'cover' }}
-          />
-        </div>
       </div>
     </div>
   );

--- a/src/components/homePage/MobileHeroCarousel.tsx
+++ b/src/components/homePage/MobileHeroCarousel.tsx
@@ -12,7 +12,9 @@ interface MobileHeroCarouselProps {
 }
 
 export default function MobileHeroCarousel({ panels }: MobileHeroCarouselProps) {
-  const [index, setIndex] = useState(0);
+  const slides = [panels[panels.length - 1], ...panels, panels[0]];
+
+  const [index, setIndex] = useState(1);
   const [enableTransition, setEnableTransition] = useState(true);
 
   // Auto‐advance every 3s
@@ -23,20 +25,19 @@ export default function MobileHeroCarousel({ panels }: MobileHeroCarouselProps) 
     return () => clearInterval(interval);
   }, []);
 
-  // When we slide past the last real panel, jump back to the first without
-  // animation once the transition completes. This creates an infinite loop that
-  // only moves forward.
+  // When we slide onto the duplicate at the end, jump back to the
+  // first real panel without animation once the transition completes.
   useEffect(() => {
-    if (index === panels.length) {
+    if (index === slides.length - 1) {
       const timeout = setTimeout(() => {
         setEnableTransition(false);
-        setIndex(0);
+        setIndex(1);
       }, 1000); // match CSS transition duration
       return () => clearTimeout(timeout);
     }
 
     setEnableTransition(true);
-  }, [index, panels.length]);
+  }, [index, slides.length]);
 
   return (
     <div className={styles.carouselWrapper}>
@@ -49,33 +50,20 @@ export default function MobileHeroCarousel({ panels }: MobileHeroCarouselProps) 
           transition: enableTransition ? 'transform 1s ease-in-out' : 'none',
         }}
       >
-        {panels.map((p, i) => (
+        {slides.map((p, i) => (
           <div key={i} className={styles.slide}>
             <div style={{ position: 'relative', width: '100%', height: '100%' }}>
               <Image
                 src={p.src}
-                alt={p.alt || `Slide ${i + 1}`}
+                alt={p.alt || ''}
                 fill
                 sizes="100vw"
-                priority={i === 0}
+                priority={i === 1}
                 style={{ objectFit: 'cover' }}
               />
             </div>
           </div>
         ))}
-        {/* Duplicate first panel to create seamless looping */}
-        <div className={styles.slide} aria-hidden="true">
-          <div style={{ position: 'relative', width: '100%', height: '100%' }}>
-            <Image
-              src={panels[0].src}
-              alt={panels[0].alt || 'Slide 1'}
-              fill
-              sizes="100vw"
-              priority={false}
-              style={{ objectFit: 'cover' }}
-            />
-          </div>
-        </div>
       </div>
 
       {/* Overlay title on top of the carousel */}


### PR DESCRIPTION
## Summary
- refine looping logic for HeroCarousel
- same update for MobileHeroCarousel

## Testing
- `npm run format`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c711b014832495a627462963de49