### PR TITLE
Update hero carousel start behaviour

### DIFF
--- a/src/components/homePage/HeroCarousel.tsx
+++ b/src/components/homePage/HeroCarousel.tsx
@@ -8,11 +8,23 @@ import styles from '@/styles/HeroCarousel.module.scss';
 interface HeroCarouselProps {
   images: { src: StaticImageData; alt?: string }[];
   intervalMs?: number;
+  /**
+   * If true, begin sliding immediately on mount rather than waiting
+   * for the first interval tick.
+   */
+  startImmediately?: boolean;
 }
 
-export default function HeroCarousel({ images, intervalMs = 3000 }: HeroCarouselProps) {
+export default function HeroCarousel({ images, intervalMs = 3000, startImmediately = false }: HeroCarouselProps) {
   const [index, setIndex] = useState(0);
   const [enableTransition, setEnableTransition] = useState(true);
+
+  useEffect(() => {
+    if (startImmediately) {
+      const t = setTimeout(() => setIndex(1), 0);
+      return () => clearTimeout(t);
+    }
+  }, [startImmediately]);
 
   // Auto‐advance
   useEffect(() => {

--- a/src/components/homePage/HeroSection.tsx
+++ b/src/components/homePage/HeroSection.tsx
@@ -30,5 +30,9 @@ export default function HeroSection() {
     return <DesktopHero panels={panels} />;
   }
 
-  return isMobile ? <MobileHeroCarousel panels={panels} /> : <DesktopHero panels={panels} />;
+  return isMobile ? (
+    <MobileHeroCarousel panels={panels} startImmediately />
+  ) : (
+    <DesktopHero panels={panels} />
+  );
 }

--- a/src/components/homePage/MobileHeroCarousel.tsx
+++ b/src/components/homePage/MobileHeroCarousel.tsx
@@ -9,11 +9,25 @@ type Panel = { src: StaticImageData; alt?: string };
 
 interface MobileHeroCarouselProps {
   panels: Panel[];
+  /**
+   * If true, advance to the second slide immediately after mount
+   * instead of waiting for the first interval tick.
+   */
+  startImmediately?: boolean;
 }
 
-export default function MobileHeroCarousel({ panels }: MobileHeroCarouselProps) {
+export default function MobileHeroCarousel({ panels, startImmediately = false }: MobileHeroCarouselProps) {
   const [index, setIndex] = useState(0);
   const [enableTransition, setEnableTransition] = useState(true);
+
+  // Optionally jump to the second slide on mount so the carousel
+  // begins animating right away.
+  useEffect(() => {
+    if (startImmediately) {
+      const t = setTimeout(() => setIndex(1), 0);
+      return () => clearTimeout(t);
+    }
+  }, [startImmediately]);
 
   // Auto‐advance every 3s
   useEffect(() => {


### PR DESCRIPTION
## Summary
- start hero carousels immediately on mount using new `startImmediately` prop
- pass the prop from `HeroSection`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842c8025544832487233570b6494e3f