### PR TITLE
Fix startImmediately prop handling

### DIFF
--- a/src/components/homePage/HeroCarousel.tsx
+++ b/src/components/homePage/HeroCarousel.tsx
@@ -16,7 +16,11 @@ interface HeroCarouselProps {
 }
 
 
-export default function HeroCarousel({ images, intervalMs = 3000 }: HeroCarouselProps) {
+export default function HeroCarousel({
+  images,
+  intervalMs = 3000,
+  startImmediately = false,
+}: HeroCarouselProps) {
   // Duplicate first and last images so we can seamlessly loop in one direction
   const slides = [images[images.length - 1], ...images, images[0]];
 


### PR DESCRIPTION
## Summary
- include `startImmediately` prop in `HeroCarousel`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842cabe6c8083248ef70ae2743fd8f1