### PR TITLE
Add tablet hero and move title to header

### DIFF
--- a/src/components/functions/Header.tsx
+++ b/src/components/functions/Header.tsx
@@ -62,6 +62,7 @@ export default function Header() {
               fetchPriority="high"
             />
           </Link>
+          <span className={styles.siteName}>Grímur Kokkur</span>
         </div>
 
         <div className={styles.controls}>

--- a/src/components/homePage/DesktopHero.tsx
+++ b/src/components/homePage/DesktopHero.tsx
@@ -13,7 +13,7 @@ interface DesktopHeroProps {
 
 export default function DesktopHero({ panels }: DesktopHeroProps) {
   return (
-    <header className={styles.hero} role="banner" aria-labelledby="hero-title">
+    <header className={styles.hero} role="banner">
       {panels.map((p, i) => {
         const isHumarsupa = /humarsupa_portrait/.test(p.src.src);
 
@@ -30,9 +30,6 @@ export default function DesktopHero({ panels }: DesktopHeroProps) {
           </div>
         );
       })}
-      <div className={styles.overlayContent}>
-        <h1 id="hero-title">Grímur Kokkur</h1>
-      </div>
     </header>
   );
 }

--- a/src/components/homePage/HeroSection.tsx
+++ b/src/components/homePage/HeroSection.tsx
@@ -3,8 +3,10 @@
 
 import { useState, useEffect } from 'react';
 import useIsMobile from './useIsMobile';
+import useIsTablet from './useIsTablet';
 import DesktopHero from './DesktopHero';
 import MobileHeroCarousel from './MobileHeroCarousel';
+import TabletHeroCarousel from './TabletHeroCarousel';
 import humarsupa from '../../../public/humarsupa_portrait.jpg';
 import fiskibollur from '../../../public/fiskibollur_portrait.jpg';
 import fiskistangir from '../../../public/fiskistangir_portrait.jpg';
@@ -28,6 +30,7 @@ export default function HeroSection() {
   }, []);
 
   const isMobile = useIsMobile();
+  const isTablet = useIsTablet();
 
   if (!mounted) {
     return <DesktopHero panels={panels} />;
@@ -35,6 +38,8 @@ export default function HeroSection() {
 
   return isMobile ? (
     <MobileHeroCarousel panels={panels} startImmediately />
+  ) : isTablet ? (
+    <TabletHeroCarousel panels={panels.slice(0, 2)} startImmediately />
   ) : (
     <DesktopHero panels={panels} />
   );

--- a/src/components/homePage/TabletHeroCarousel.tsx
+++ b/src/components/homePage/TabletHeroCarousel.tsx
@@ -1,21 +1,19 @@
-// src/components/homePage/MobileHeroCarousel.tsx
+// src/components/homePage/TabletHeroCarousel.tsx
 'use client';
 
 import { useEffect, useState } from 'react';
 import Image, { type StaticImageData } from 'next/image';
 import styles from '@/styles/HeroCarousel.module.scss';
 
-type Panel = { src: StaticImageData; alt?: string };
-
-interface MobileHeroCarouselProps {
-  panels: Panel[];
+interface TabletHeroCarouselProps {
+  panels: { src: StaticImageData; alt?: string }[];
   startImmediately?: boolean;
 }
-/**
- * Mobile version of the hero section with automatic carousel cycling.
- */
 
-export default function MobileHeroCarousel({ panels, startImmediately }: MobileHeroCarouselProps) {
+/**
+ * Tablet version of the hero section cycling through images like the mobile carousel.
+ */
+export default function TabletHeroCarousel({ panels, startImmediately }: TabletHeroCarouselProps) {
   const [index, setIndex] = useState(0);
 
   useEffect(() => {

--- a/src/components/homePage/useIsTablet.ts
+++ b/src/components/homePage/useIsTablet.ts
@@ -1,0 +1,26 @@
+// src/components/homePage/useIsTablet.ts
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Determines if the screen width is between 769px and 1024px.
+ */
+export default function useIsTablet(): boolean | undefined {
+  const [isTablet, setIsTablet] = useState<boolean | undefined>(undefined);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      setIsTablet(false);
+      return;
+    }
+    const mql = window.matchMedia('(min-width: 769px) and (max-width: 1024px)');
+    setIsTablet(mql.matches);
+
+    const handler = (e: MediaQueryListEvent) => setIsTablet(e.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
+
+  return isTablet;
+}

--- a/src/styles/Header.module.scss
+++ b/src/styles/Header.module.scss
@@ -41,6 +41,12 @@
   align-items: center;
 }
 
+.siteName {
+  margin-left: v.$spacing-sm;
+  font-size: clamp(1.25rem, 3vw, 1.5rem);
+  font-weight: 700;
+}
+
 .controls {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- move the site name beside the logo in the header
- remove hero overlay title
- add a tablet carousel version of the hero section
- detect tablet viewport width to switch hero variant

## Testing
- `npm run format`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ecfe3fcc8324a15e3413d84c2650