### PR TITLE
Update tablet hero carousel

### DIFF
--- a/src/components/homePage/HeroSection.tsx
+++ b/src/components/homePage/HeroSection.tsx
@@ -39,7 +39,7 @@ export default function HeroSection() {
   return isMobile ? (
     <MobileHeroCarousel panels={panels} startImmediately />
   ) : isTablet ? (
-    <TabletHeroCarousel panels={panels.slice(0, 2)} startImmediately />
+    <TabletHeroCarousel panels={panels} startImmediately />
   ) : (
     <DesktopHero panels={panels} />
   );

--- a/src/components/homePage/TabletHeroCarousel.tsx
+++ b/src/components/homePage/TabletHeroCarousel.tsx
@@ -16,6 +16,11 @@ interface TabletHeroCarouselProps {
 export default function TabletHeroCarousel({ panels, startImmediately }: TabletHeroCarouselProps) {
   const [index, setIndex] = useState(0);
 
+  const pairs: { src: StaticImageData; alt?: string }[][] = [];
+  for (let i = 0; i < panels.length; i += 2) {
+    pairs.push(panels.slice(i, i + 2));
+  }
+
   useEffect(() => {
     if (startImmediately) {
       const t = setTimeout(() => setIndex(1), 0);
@@ -25,25 +30,29 @@ export default function TabletHeroCarousel({ panels, startImmediately }: TabletH
 
   useEffect(() => {
     const interval = setInterval(() => {
-      setIndex((i) => (i + 1) % panels.length);
+      setIndex((i) => (i + 1) % pairs.length);
     }, 3000);
     return () => clearInterval(interval);
-  }, [panels.length]);
+  }, [pairs.length]);
 
   return (
     <div className={styles.carouselWrapper}>
       <div className={styles.slides} aria-live="polite" aria-atomic="true">
-        {panels.map((p, i) => (
+        {pairs.map((pair, i) => (
           <div key={i} className={styles.slide} style={{ opacity: i === index ? 1 : 0 }}>
-            <div style={{ position: 'relative', width: '100%', height: '100%' }}>
-              <Image
-                src={p.src}
-                alt={p.alt || ''}
-                fill
-                sizes="100vw"
-                priority={i === 0}
-                style={{ objectFit: 'cover' }}
-              />
+            <div className={styles.pair}>
+              {pair.map((p, j) => (
+                <div key={j} className={styles.pairImage}>
+                  <Image
+                    src={p.src}
+                    alt={p.alt || ''}
+                    fill
+                    sizes="50vw"
+                    priority={i === 0 && j === 0}
+                    style={{ objectFit: 'cover' }}
+                  />
+                </div>
+              ))}
             </div>
           </div>
         ))}

--- a/src/styles/HeroCarousel.module.scss
+++ b/src/styles/HeroCarousel.module.scss
@@ -18,6 +18,17 @@
   transition: opacity 1s ease-in-out;
 }
 
+.pair {
+  display: flex;
+  width: 100%;
+  height: 100%;
+}
+
+.pairImage {
+  position: relative;
+  flex: 1;
+}
+
 .overlayContent {
   position: absolute;
   top: 1.5rem;


### PR DESCRIPTION
## Summary
- update tablet carousel to show two images at once
- reuse the mobile fade animation

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f25323c88324ae2fe536e4b53271