### PR TITLE
Fix logo hydration mismatch

### DIFF
--- a/src/components/functions/Header.tsx
+++ b/src/components/functions/Header.tsx
@@ -58,8 +58,10 @@ export default function Header() {
               alt="Grímur Kokkur logo"
               width={100}
               height={100}
+              // `priority` already sets fetchPriority="high" and loading="eager" on the server.
+              // Explicitly passing fetchPriority caused a hydration mismatch in React 19.
+              // Removing it keeps the markup consistent between server and client.
               priority
-              fetchPriority="high"
             />
           </Link>
           <span className={styles.siteName}>Grímur Kokkur</span>


### PR DESCRIPTION
## Summary
- avoid hydration issues on Next.js logo

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f862b99883248c92c4af9a3114d0