### PR TITLE
Add ErrorBoundary for graceful client errors

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,11 @@ import Header from '@/components/functions/Header';
 import Footer from '@/components/functions/Footer';
 import { Analytics } from '@vercel/analytics/next';
 import BackToTop from '@/components/functions/BackToTop';
+import dynamic from 'next/dynamic';
+
+const ErrorBoundary = dynamic(() => import('@/components/ErrorBoundary'), {
+  ssr: false,
+});
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -64,14 +69,16 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           Sleppa í efni
         </a>
 
-        <Header />
+        <ErrorBoundary>
+          <Header />
 
-        <main id="main-content">{children}</main>
+          <main id="main-content">{children}</main>
 
-        <Footer />
-        <Analytics />
+          <Footer />
+          <Analytics />
 
-        <BackToTop />
+          <BackToTop />
+        </ErrorBoundary>
       </body>
     </html>
   );

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+interface State {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(_: Error): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('Uncaught error:', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div style={{ padding: '2rem', textAlign: 'center' }}>
+          <h2>Óvænt villa kom upp</h2>
+          <p>Vinsamlegast endurhlaðið síðuna og reynið aftur.</p>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `ErrorBoundary` to display fallback UI on uncaught errors
- wrap site layout with the new boundary

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fa8dd9dc8324ab4d5203480f69f1