### PR TITLE
Add TSDoc comments and SCSS style guide

### DIFF
--- a/SCSS_DOC.md
+++ b/SCSS_DOC.md
@@ -1,0 +1,32 @@
+# SCSS Style Guide
+
+This project uses modular SCSS with a small set of shared variables and mixins. Below is a brief overview of the available helpers.
+
+## Variables (`src/styles/_variables.scss`)
+
+- **Colors**
+  - `$color-foreground`, `$color-background`, `$color-card-bg`, `$color-accent-bg`
+  - `$color-primary`, `$color-primary-light`
+  - `$color-success`, `$color-error`
+  - `$color-border`, `$color-text-muted`
+- **Typography**
+  - `$font-sans`, `$font-mono`
+- **Spacing**
+  - `$spacing-xs`, `$spacing-sm`, `$spacing-md`, `$spacing-lg`
+- **Border radius**
+  - `$radius-sm`, `$radius-md`, `$radius-lg`
+- **Breakpoints** (`$breakpoints` map)
+  - `xs`, `sm`, `md`, `lg`, `xl`
+
+These variables are exposed to CSS custom properties in `globals.scss` for easy theming.
+
+## Mixins (`src/styles/_mixins.scss`)
+
+- `slanted-edge($side, $height)` – Adds a slanted pseudo element on the chosen side.
+- `respond-to($break)` – Media query helper that looks up the breakpoint value from `$breakpoints`.
+
+## Helpers
+
+- Utility classes such as `.truncate` are defined in `_helpers.scss`.
+
+Import `globals.scss` once in your application to load the base styles and variables.

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -8,6 +8,9 @@ const TS_SECRET = process.env.TS_TOKEN_SECRET!;
 const MIN_AGE = 3_000;
 const MAX_AGE = 3_600_000;
 
+/**
+ * Handles contact form submissions with bot protection and validation.
+ */
 export async function POST(request: Request) {
   const body = await request.json();
 

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -9,6 +9,9 @@ export const metadata = {
   description: 'Sendu okkur skilaboð eða fyrirspurnir í gegnum formið hér að neðan.',
 };
 
+/**
+ * Static contact page that signs a timestamp token and passes it to the client component.
+ */
 export default function ContactPage() {
   const ts = Date.now().toString();
   const tsSignature = createHmac('sha256', process.env.TS_TOKEN_SECRET!).update(ts).digest('hex');

--- a/src/app/contact/pageClient.tsx
+++ b/src/app/contact/pageClient.tsx
@@ -15,6 +15,9 @@ type ContactInput = {
 
 type Status = 'idle' | 'pending' | 'success' | 'error';
 
+/**
+ * Client side of the contact page handling form state and submission.
+ */
 export default function ContactPageClient({ ts, tsSignature }: Props) {
   const [form, setForm] = useState<ContactInput>({
     name: '',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,6 +30,9 @@ export const metadata: Metadata = {
   },
 };
 
+/**
+ * Root layout wrapping all pages with global providers and metadata.
+ */
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="is">

--- a/src/components/about/AboutSections.tsx
+++ b/src/components/about/AboutSections.tsx
@@ -14,6 +14,10 @@ interface AboutSectionsProps {
   sections: AboutSection[];
 }
 
+/**
+ * Displays all sections from the about page, including hero images,
+ * markdown text and optional photo galleries.
+ */
 export default function AboutSections({ sections }: AboutSectionsProps) {
   return (
     <>

--- a/src/components/functions/Footer.tsx
+++ b/src/components/functions/Footer.tsx
@@ -7,6 +7,9 @@ import Link from 'next/link';
 import { Instagram, Facebook } from 'lucide-react';
 import styles from '@/styles/Footer.module.scss';
 
+/**
+ * Site footer containing contact info, logo and social links.
+ */
 export default function Footer() {
   return (
     <footer className={styles.footer}>

--- a/src/components/functions/Header.tsx
+++ b/src/components/functions/Header.tsx
@@ -13,6 +13,9 @@ const navLinks = [
   { href: '/about', label: 'Um okkur' },
   { href: '/contact', label: 'Hafðu samband' },
 ];
+/**
+ * Responsive header with navigation links and a toggle for mobile screens.
+ */
 
 export default function Header() {
   const [menuOpen, setMenuOpen] = useState(false);


### PR DESCRIPTION
## Summary
- add missing TSDoc comments for several components and API route
- include SCSS_DOC.md with overview of styling helpers

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_685917d237448324aadc56983378404d